### PR TITLE
Added typings and fix for message length error

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -26,19 +26,11 @@ declare module "webhook-discord" {
      */
     public warn(name: string, message: string): void;
 
-    /**
-     *  @param {string} name The username of the custom webhook.
-     *  @param {string} message The message of the custom webhook.
-     *  @param {string} title The title of the custom webhook.
-     *  @param {string} color The color of the custom webhook. (optional)
-     *  @param {string} imageUrl The url of the image to attach (optional)
-     */
-    public custom(name: string, message: string, title: string, color: string, imageUrl: string): void;
   }
 
   // tslint:disable-next-line:max-classes-per-file
   export class MessageBuilder {
-    constructor(name?: string, color?: string, text?: string, image?: string, time?: number);
+    constructor();
 
     /**
      * Add an avatar to the webhooks

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,77 @@
+declare module "webhook-discord" {
+  export class Webhook {
+    constructor(url: string, nowait?: boolean);
+  }
+
+  // tslint:disable-next-line:max-classes-per-file
+  export class MessageBuilder {
+    constructor(name?: string, color?: string, text?: string, image?: string, time?: number);
+
+    /**
+     * Add an avatar to the webhooks
+     *
+     * @param {string} avatarURL The URL to the avatar.
+     */
+    public setAvatar(avatarURL: string): void;
+
+    /**
+     * This method sets the username of the hook
+     *
+     * @param {string} username The username to use
+     */
+    public setName(username: string): void;
+
+    /**
+     * Set the footer of the embed
+     *
+     * @param {string} footer The footer to use
+     * @param {string} footerIcon The icon to display in the footer
+     */
+    public setFooter(footer: string, footerIcon: string): void;
+
+    /**
+     * Set the description of the embed
+     *
+     * @param {string} description The description to use
+     */
+    public setDescription(description: string): void;
+
+    /**
+     * Set the text to be sent alongside the embed.
+     *
+     * @param {string} text The text.
+     */
+    public setText(text: string): void;
+
+    /**
+     * This method adds a new field to the embed.
+     *
+     * @param {string} title The title of the field.
+     * @param {string} value The value of the field.
+     * @param {bool} inline Should the field be an inline field
+     */
+    public addField(title: string, value: string, inline?: boolean): void;
+
+    /**
+     * This method adds an image to the embed.
+     *
+     * @param {string} imageURL The URL to the image.
+     */
+    public setImage(imageURL: string): void;
+
+    /**
+     * Set timestamp, if no argument is passed, the current
+     * time is used.
+     *
+     * @param {number} timestamp The timestamp to use.
+     */
+    public setTime(timestamp?: number): void;
+
+    /**
+     * This method sets the color of the embed.
+     *
+     * @param {string} color The hexadecimal color
+     */
+    public setColor(color: string): void;
+  }
+}

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,39 @@
 declare module "webhook-discord" {
   export class Webhook {
     constructor(url: string, nowait?: boolean);
+
+    /**
+     * @param {string} name The username of the success webhook.
+     * @param {string} message The message of the success webhook.
+     */
+    public success(name: string, message: string): void;
+
+    /**
+     * @param {string} name The username of the info webhook.
+     * @param {string} message The message of the info webhook.
+     */
+    public info(name: string, message: string): void;
+
+    /**
+     * @param {string} name The username of the error webhook.
+     * @param {string} message The message of the error webhook.
+     */
+    public err(name: string, message: string): void;
+
+    /**
+     *   @param {string} name The username of the warning webhook.
+     *   @param {string} message The message of the warning webhook.
+     */
+    public warn(name: string, message: string): void;
+
+    /**
+     *  @param {string} name The username of the custom webhook.
+     *  @param {string} message The message of the custom webhook.
+     *  @param {string} title The title of the custom webhook.
+     *  @param {string} color The color of the custom webhook. (optional)
+     *  @param {string} imageUrl The url of the image to attach (optional)
+     */
+    public custom(name: string, message: string, title: string, color: string, imageUrl: string): void;
   }
 
   // tslint:disable-next-line:max-classes-per-file

--- a/index.d.ts
+++ b/index.d.ts
@@ -45,14 +45,14 @@ declare module "webhook-discord" {
      *
      * @param {string} avatarURL The URL to the avatar.
      */
-    public setAvatar(avatarURL: string): void;
+    public setAvatar(avatarURL: string): MessageBuilder;
 
     /**
      * This method sets the username of the hook
      *
      * @param {string} username The username to use
      */
-    public setName(username: string): void;
+    public setName(username: string): MessageBuilder;
 
     /**
      * Set the footer of the embed
@@ -60,21 +60,21 @@ declare module "webhook-discord" {
      * @param {string} footer The footer to use
      * @param {string} footerIcon The icon to display in the footer
      */
-    public setFooter(footer: string, footerIcon: string): void;
+    public setFooter(footer: string, footerIcon: string): MessageBuilder;
 
     /**
      * Set the description of the embed
      *
      * @param {string} description The description to use
      */
-    public setDescription(description: string): void;
+    public setDescription(description: string): MessageBuilder;
 
     /**
      * Set the text to be sent alongside the embed.
      *
      * @param {string} text The text.
      */
-    public setText(text: string): void;
+    public setText(text: string): MessageBuilder;
 
     /**
      * This method adds a new field to the embed.
@@ -83,14 +83,14 @@ declare module "webhook-discord" {
      * @param {string} value The value of the field.
      * @param {bool} inline Should the field be an inline field
      */
-    public addField(title: string, value: string, inline?: boolean): void;
+    public addField(title: string, value: string, inline?: boolean): MessageBuilder;
 
     /**
      * This method adds an image to the embed.
      *
      * @param {string} imageURL The URL to the image.
      */
-    public setImage(imageURL: string): void;
+    public setImage(imageURL: string): MessageBuilder;
 
     /**
      * Set timestamp, if no argument is passed, the current
@@ -98,13 +98,13 @@ declare module "webhook-discord" {
      *
      * @param {number} timestamp The timestamp to use.
      */
-    public setTime(timestamp?: number): void;
+    public setTime(timestamp?: number): MessageBuilder;
 
     /**
      * This method sets the color of the embed.
      *
      * @param {string} color The hexadecimal color
      */
-    public setColor(color: string): void;
+    public setColor(color: string): MessageBuilder;
   }
 }

--- a/lib/webhook.js
+++ b/lib/webhook.js
@@ -41,6 +41,15 @@ class Webhook {
         }
     }
 
+     /**
+     * Check the message length, because discord is rejecting messages containing more than 1000 chararacters.
+     * @param {string} message 
+     */
+    checkMessageLength(message) {
+        if (message.length > 1000)
+            throw new Error(`The message given was ${message.length}. Discord webhook messages must be under 1000 characters`);
+    }
+
     /**
     @param {object} payloadRaw The payload to send.
     @param {function} resolveFunction Used internally for ratelimiting handling
@@ -48,6 +57,7 @@ class Webhook {
     sendPayload(payloadRaw, resolveFunction) {
         let payload = this.sanitiseEmbeds(payloadRaw);
         this.verifyName(payload.username);
+        this.checkMessageLength(payload.attachments[0].fields[0].value);
         if (this.ready) {
             return new Promise((resolve, reject) => {
                 snekfetch.post(this.endpoint)

--- a/lib/webhook.js
+++ b/lib/webhook.js
@@ -46,8 +46,8 @@ class Webhook {
      * @param {string} message 
      */
     checkMessageLength(message) {
-        if (message.length > 1000)
-            throw new Error(`The message given was ${message.length}. Discord webhook messages must be under 1000 characters`);
+        if (message.length > 1024)
+            throw new Error(`The message given was ${message.length} characters, fields of Discord embeds must be under 1024 characters`);
     }
 
     /**

--- a/lib/webhook.js
+++ b/lib/webhook.js
@@ -42,12 +42,23 @@ class Webhook {
     }
 
      /**
-     * Check the message length, because discord is rejecting messages containing more than 1000 chararacters.
-     * @param {string} message 
+     * Check the value length, because discord is rejecting fields containing more than 1024 chararacters in a value.
+     * @param {string} value 
      */
-    checkMessageLength(message) {
-        if (message.length > 1024)
+    checkFieldValueLength(value) {
+        if (value.length > 1024)
             throw new Error(`The message given was ${message.length} characters, fields of Discord embeds must be under 1024 characters`);
+    }
+
+    
+     /**
+     * Check 
+     * @param {fields} fields 
+     */
+    checkFields(fields) {
+        for (i = 0; i < fields.length; i++) { 
+            this.checkFieldValueLength(fields[i].value);
+        }
     }
 
     /**
@@ -58,6 +69,7 @@ class Webhook {
         let payload = this.sanitiseEmbeds(payloadRaw);
         this.verifyName(payload.username);
         this.checkMessageLength(payload.attachments[0].fields[0].value);
+        this.checkFields(payload.attachments[0]);
         if (this.ready) {
             return new Promise((resolve, reject) => {
                 snekfetch.post(this.endpoint)

--- a/lib/webhook.js
+++ b/lib/webhook.js
@@ -31,34 +31,43 @@ class Webhook {
     }
 
     /**
-    Verify the name of a webhook.
-
-    @param {string} name The name of the webhook
-    */
+     * Verify the name of a webhook.
+     * @param {string} name The name of the webhook
+     */
     verifyName(name) {
         if (name.length > 32) {
             throw new Error(`The name specified was ${name.length} characters. Discord webhook names must be under 32 characters`);
         }
     }
 
-     /**
-     * Check the value length, because discord is rejecting fields containing more than 1024 chararacters in a value.
+
+    /**
+     * Check a fields value length, because discord is rejecting fields containing more than 1024 chararacters in a value.
      * @param {string} value 
      */
     checkFieldValueLength(value) {
         if (value.length > 1024)
-            throw new Error(`The message given was ${message.length} characters, fields of Discord embeds must be under 1024 characters`);
+            throw new Error(`The value given was ${value.length} characters, fields of Discord embeds must be under 1024 characters`);
     }
 
-    
-     /**
-     * Check 
+
+    /**
+     * Checks every field in the only possible attachment.
      * @param {fields} fields 
      */
     checkFields(fields) {
-        for (i = 0; i < fields.length; i++) { 
-            this.checkFieldValueLength(fields[i].value);
-        }
+        return new Promise((resolve, reject) => {
+            const checks = [];
+
+            for (var i = 0; i < fields.length; i++) {
+                checks.push(this.checkFieldValueLength(fields[i].value));
+            }
+
+            Promise.all(checks).then(() => {
+                resolve();
+            })
+        })
+
     }
 
     /**
@@ -68,40 +77,41 @@ class Webhook {
     sendPayload(payloadRaw, resolveFunction) {
         let payload = this.sanitiseEmbeds(payloadRaw);
         this.verifyName(payload.username);
-        this.checkMessageLength(payload.attachments[0].fields[0].value);
-        this.checkFields(payload.attachments[0]);
-        if (this.ready) {
-            return new Promise((resolve, reject) => {
-                snekfetch.post(this.endpoint)
-                    .send(payload)
-                    .then(() => {
-                        if (resolveFunction) {
-                            resolveFunction();
-                        }
+        this.checkFields(payload.attachments[0].fields).then(() => {
+            if (this.ready) {
+                return new Promise((resolve, reject) => {
+                    snekfetch.post(this.endpoint)
+                        .send(payload)
+                        .then(() => {
+                            if (resolveFunction) {
+                                resolveFunction();
+                            }
 
-                        resolve();
-                    })
-                    .catch((err) => {
-                        let e = JSON.parse(err.text);
+                            resolve();
+                        })
+                        .catch((err) => {
+                            let e = JSON.parse(err.text);
 
-                        if (e.code === 50006) { // We've sent an empty message
-                            reject({error: "No content specified"});
-                        }
+                            if (e.code === 50006) { // We've sent an empty message
+                                reject({ error: "No content specified" });
+                            }
 
-                        if (e.retry_after) { // We are being ratelimited
-                            setTimeout(() => {
-                                this.sendPayload(payload, resolve);
-                            }, e.retry_after);
-                        } else {
-                            reject(err);
-                        }
-                    });
-            });
-        } else {
-            setTimeout(() => {
-                this.sendPayload(payload);
-            }, 10);
-        }
+                            if (e.retry_after) { // We are being ratelimited
+                                setTimeout(() => {
+                                    this.sendPayload(payload, resolve);
+                                }, e.retry_after);
+                            } else {
+                                reject(err);
+                            }
+                        });
+                });
+            } else {
+                setTimeout(() => {
+                    this.sendPayload(payload);
+                }, 10);
+            }
+        });
+
     }
 
     /**
@@ -109,7 +119,7 @@ class Webhook {
     */
     get endpoint() {
         let qs = "";
-        if(this.nowait){
+        if (this.nowait) {
             qs = "?wait=false";
         }
         return `${ENDPOINT}/${this.id}/${this.token}/slack${qs}`;
@@ -277,7 +287,7 @@ class Webhook {
         return new Promise((resolve, reject) => {
             // Discord will return an angry error if we don't specify a username
             if (!messageBuilder.data.username) {
-                reject({error: "No username provided"});
+                reject({ error: "No username provided" });
             }
 
 
@@ -291,7 +301,7 @@ class Webhook {
             ) {
                 return this.sendPayload(messageBuilder.data, resolve);
             } else {
-                reject({error: "No content specified"});
+                reject({ error: "No content specified" });
             }
         });
     }


### PR DESCRIPTION
Added missing typings and added a fix to prevent discord rejecting the hook.
Closes #37 and #43 

The message check is only done for the first attachment and the first fields inside this attachment. If it is possible to add more attachments or fields, I will add this check aswell.