### PR TITLE
Implement setAuthor and setURL for MessageBuilder

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -99,22 +99,24 @@ declare module "webhook-discord" {
     public setTime(timestamp?: number): MessageBuilder;
 
     /**
-     * Set the title for the discord hook
-     * @param title the webhooks´ title
+     * Set the title of the embed
+     *
+     * @param {string} title The title to use
      */
     public setTitle(title: string): MessageBuilder;
 
     /**
-     * Set the author of the embedded object
-     * @param author the authors name
-     * @param iconURL the icon url
-     * @param url the url
+     * Set the author of the embed
+     * @param {string} author Name of the author
+     * @param {string} iconURL Optional: Icon URL of the author
+     * @param {string} url Optional: Link to the author
      */
     public setAuthor(author: string, iconURL?: string, url?: string): MessageBuilder;
 
     /**
-     * Set the url for the discord hook
-     * @param url the url
+     * Set the URL for the Discord embed
+     * 
+     * @param {string} url The URL to link to from the embed.
      */
     public setURL(url: string): MessageBuilder;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -99,6 +99,26 @@ declare module "webhook-discord" {
     public setTime(timestamp?: number): MessageBuilder;
 
     /**
+     * 
+     * @param title the webhooks´ title
+     */
+    public setTitle(title: string): MessageBuilder;
+
+    /**
+     * 
+     * @param author the authors name
+     * @param iconURL the icon url
+     * @param url the url
+     */
+    public setAuthor(author: string, iconURL?: string, url?: string): MessageBuilder;
+
+    /**
+     * 
+     * @param url the url
+     */
+    public setURL(url: string): MessageBuilder;
+
+    /**
      * This method sets the color of the embed.
      *
      * @param {string} color The hexadecimal color

--- a/index.d.ts
+++ b/index.d.ts
@@ -99,13 +99,13 @@ declare module "webhook-discord" {
     public setTime(timestamp?: number): MessageBuilder;
 
     /**
-     * 
+     * Set the title for the discord hook
      * @param title the webhooks´ title
      */
     public setTitle(title: string): MessageBuilder;
 
     /**
-     * 
+     * Set the author of the embedded object
      * @param author the authors name
      * @param iconURL the icon url
      * @param url the url
@@ -113,7 +113,7 @@ declare module "webhook-discord" {
     public setAuthor(author: string, iconURL?: string, url?: string): MessageBuilder;
 
     /**
-     * 
+     * Set the url for the discord hook
      * @param url the url
      */
     public setURL(url: string): MessageBuilder;

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -94,7 +94,7 @@ class MessageBuilder {
     }
 
     /**
-     * 
+     * Set the embedded url
      * @param {string} url The url 
      */
     setURL(url) {
@@ -103,10 +103,10 @@ class MessageBuilder {
     }
 
     /**
-     * 
-     * @param {string} author 
-     * @param {string} iconURL 
-     * @param {string} url 
+     * Set the author of the embedded object
+     * @param {string} author the author
+     * @param {string} iconURL Optional: the icon url
+     * @param {string} url Optional: the url
      */
     setAuthor(author, iconURL, url) {
         this.data.attachments[0].author = author;

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -94,29 +94,30 @@ class MessageBuilder {
     }
 
     /**
-     * Set the embedded url
-     * @param {string} url The url 
+     * Set the URL for the Discord embed
+     * 
+     * @param {string} url The URL to link to from the embed.
      */
     setURL(url) {
-        this.data.attachments[0].url = url;
+        this.data.attachments[0].title_link = url;
         return this;
     }
 
     /**
-     * Set the author of the embedded object
-     * @param {string} author the author
-     * @param {string} iconURL Optional: the icon url
-     * @param {string} url Optional: the url
+     * Set the author of the embed
+     * @param {string} author Name of the author
+     * @param {string} iconURL Optional: Icon URL of the author
+     * @param {string} url Optional: Link to the author
      */
     setAuthor(author, iconURL, url) {
-        this.data.attachments[0].author = author;
+        this.data.attachments[0].author_name = author;
 
         if (iconURL) {
-            this.data.attachments[0].icon_url = iconURL;
+            this.data.attachments[0].author_icon = iconURL;
         }
 
         if (url) {
-            this.data.attachments[0].url = url;
+            this.data.attachments[0].author_link = url;
         }
 
         return this;

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -94,6 +94,35 @@ class MessageBuilder {
     }
 
     /**
+     * 
+     * @param {string} url The url 
+     */
+    setURL(url) {
+        this.data.attachments[0].url = url;
+        return this;
+    }
+
+    /**
+     * 
+     * @param {string} author 
+     * @param {string} iconURL 
+     * @param {string} url 
+     */
+    setAuthor(author, iconURL, url) {
+        this.data.attachments[0].author = author;
+
+        if (iconURL) {
+            this.data.attachments[0].icon_url = iconURL;
+        }
+
+        if (url) {
+            this.data.attachments[0].url = url;
+        }
+
+        return this;
+    }
+
+    /**
      * This method adds a new field to the embed.
      *
      * @param {string} title The title of the field.


### PR DESCRIPTION
The scope is to implement missing methods mentioned here #52, to be precise setAuthor and setUrl, which sets the author / url respectively.

Additional, those methods are added to the typescript index.d.t.s file.